### PR TITLE
refactor(control block)!: Change from braces to indentation for control blocks

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/src/main/kotlin/host/minestudio/craftlang/language/parsing/Parser.kt
+++ b/src/main/kotlin/host/minestudio/craftlang/language/parsing/Parser.kt
@@ -33,7 +33,7 @@ class Parser(private val tokens: List<Token>) {
     private fun declaration(): Statement {
         try {
             if (match(TokenType.CLASS)) return classDeclaration()
-            if (match(TokenType.FUN)) return function("function")
+            if (match(TokenType.FUNCTION)) return function("function")
             if (match(TokenType.SET)) return setter()
 
             return statement()
@@ -58,7 +58,7 @@ class Parser(private val tokens: List<Token>) {
         val methods = mutableListOf<Statement.FunctionStatement>()
         while (isIndentation()) {
             consumeIndentation()
-            consume(TokenType.FUN, "Expect method declaration.")
+            consume(TokenType.FUNCTION, "Expect method declaration.")
             methods.add(function("method"))
         }
 
@@ -486,7 +486,7 @@ class Parser(private val tokens: List<Token>) {
         while (!isAtEnd()) {
 
             when (peek().type) {
-                TokenType.CLASS, TokenType.FUN, TokenType.SET, TokenType.FOR, TokenType.IF, TokenType.WHILE, TokenType.PRINT, TokenType.RETURN -> return
+                TokenType.CLASS, TokenType.FUNCTION, TokenType.SET, TokenType.FOR, TokenType.IF, TokenType.WHILE, TokenType.PRINT, TokenType.RETURN -> return
                 else -> advance()
             }
         }

--- a/src/main/kotlin/host/minestudio/craftlang/language/parsing/Parser.kt
+++ b/src/main/kotlin/host/minestudio/craftlang/language/parsing/Parser.kt
@@ -6,11 +6,19 @@ import host.minestudio.craftlang.language.scanning.Token
 import host.minestudio.craftlang.language.scanning.TokenType
 import host.minestudio.craftlang.language.stmt.Statement
 
-
 class Parser(private val tokens: List<Token>) {
     private class ParseError(message: String) : RuntimeException(message)
+    private enum class Indentation(val type: TokenType? = null, val amount: Int = 1) {
+        TAB(TokenType.TAB),
+        FOUR_SPACES(TokenType.SPACE, 4),
+        TWO_SPACES(TokenType.SPACE, 2),
+        ONE_SPACE(TokenType.SPACE),
+        NONE(null, 0)
+    }
 
     private var current = 0
+    private var indentation = Indentation.NONE
+    private var depth = 0
 
     fun parse(): List<Statement> {
         val statements = mutableListOf<Statement>()
@@ -39,19 +47,22 @@ class Parser(private val tokens: List<Token>) {
         val name = consume(TokenType.IDENTIFIER, "Expect class name.")
 
         val superclass =
-            if (match(TokenType.COLON))
+            if (match(TokenType.DOUBLE_COLON))
                 Expr.Variable(consume(TokenType.IDENTIFIER, "Expect superclass name."))
             else null
 
-        consume(TokenType.LEFT_BRACE, "Expect '{' before class body.")
+        consume(TokenType.COLON, "Expect ':' before class body.")
+        depth++
+        indentation = indentationType()
 
         val methods = mutableListOf<Statement.FunctionStatement>()
-        while (!check(TokenType.RIGHT_BRACE) && !isAtEnd()) {
+        while (isIndentation()) {
+            consumeIndentation()
             consume(TokenType.FUN, "Expect method declaration.")
             methods.add(function("method"))
         }
 
-        consume(TokenType.RIGHT_BRACE, "Expect '}' after class body.")
+        depth--
 
         return Statement.ClassStatement(name, superclass, methods)
     }
@@ -79,7 +90,7 @@ class Parser(private val tokens: List<Token>) {
             consume(TokenType.IDENTIFIER, "Expect return type.")
         }
 
-        consume(TokenType.LEFT_BRACE, "Expect '{' before $kind body.")
+        consume(TokenType.COLON, "Expect ':' before $kind body.")
 
         val body = block()
         return Statement.FunctionStatement(name, parameters, body)
@@ -109,7 +120,7 @@ class Parser(private val tokens: List<Token>) {
         if (match(TokenType.PRINT)) return printStatement()
         if (match(TokenType.RETURN)) return returnStatement()
         if (match(TokenType.WHILE)) return whileStatement()
-        if (match(TokenType.LEFT_BRACE)) return Statement.BlockStatement(block())
+        if (match(TokenType.COLON)) return Statement.BlockStatement(block())
 
         return expressionStatement()
     }
@@ -118,10 +129,8 @@ class Parser(private val tokens: List<Token>) {
         val condition = expression()
 
         val thenBranch = statement()
-        var elseBranch: Statement? = null
-        if (match(TokenType.ELSE)) {
-            elseBranch = statement()
-        }
+        // Next token is an ELSE and indentation is the same
+        val elseBranch = if (consumeAfterIndentation(TokenType.ELSE)) statement() else null
 
         return Statement.IfStatement(condition, thenBranch, elseBranch)
     }
@@ -152,11 +161,20 @@ class Parser(private val tokens: List<Token>) {
     private fun block(): List<Statement> {
         val statements = mutableListOf<Statement>()
 
-        while (!check(TokenType.RIGHT_BRACE) && !isAtEnd()) {
+        val enclosing = indentation
+        indentation = indentationType()
+        depth++
+
+        while (!isAtEnd() && peek().type == indentation.type) {
+            if (!isIndentation()) break
+            consumeIndentation()
+
             statements.add(declaration())
         }
 
-        consume(TokenType.RIGHT_BRACE, "Expect '}' after block.")
+        depth--
+        indentation = enclosing
+
         return statements
     }
 
@@ -307,7 +325,96 @@ class Parser(private val tokens: List<Token>) {
     }
 
 
+    /**
+     * Gets the amount of indentation elements (spaces/tabs)
+     */
+    private fun getIndentation(): Int {
+        return checkAmount(indentation.type!!)
+    }
 
+    /**
+     * Validates the indentation for the current line.
+     * @return `true` if the indentation is correct, `false` if it's a de-indent.
+     * @throws ParseError if the indentation is invalid. (e.g. too many spaces, 3 spaces, etc.)
+     */
+    private fun isIndentation(): Boolean {
+        val amount = getIndentation()
+        if (amount != indentation.amount * (depth)) {  // Non-matching indentation
+            if (amount == indentation.amount * (depth - 1)) return false // De-indented line, return false
+
+            val type = if (indentation.type == TokenType.SPACE) "spaces" else "tabs"
+            throw error(peek(), "Invalid indentation. " +
+                    "Expected ${indentation.amount} $type, found $amount.")
+        }
+
+        return true // Indentation is correct
+    }
+
+    /**
+     * Consumes the indentation for the current line.
+     * @return `true` if indentation is the same, `false` if it's a de-indent.
+     */
+    private fun consumeIndentation(): Boolean {
+        val startLine = peek().line
+        matchAmount(indentation.type!!) // Consume the indentation after it's validated
+
+        if (peek().line != startLine) {
+            // Line is empty, consume the indentation for the next line
+            return if (isIndentation()) consumeIndentation() else false
+        }
+
+        return true
+    }
+
+    /**
+     * Consumes the token (and indentation) if it's the same as the given type after the indentation.
+     * @return `true` if the token was consumed, `false` if it wasn't.
+     */
+    private fun consumeAfterIndentation(type: TokenType): Boolean {
+        if (isIndentation() && (peek(getIndentation()).type == type)) { // Indentation matches AND next token matches?
+            consumeIndentation()
+            consume(type, "CRITICAL ERROR: Found `${type.name}` then lost it? " +
+                    "MAKE AN ISSUE ON https://github.com/MineStudio-Host/CraftLang WITH YOUR CODE.")
+            return true
+        }
+
+        return false
+    }
+
+    /**
+     * Gets the type of indentation based on the current line.
+     * (or, if the indentation for this block is already set, returns that)
+     */
+    private fun indentationType(): Indentation {
+        return if (indentation != Indentation.NONE) indentation else when (peek().type) {
+            TokenType.TAB -> Indentation.TAB
+            TokenType.SPACE -> {
+                when (val amount = checkAmount(TokenType.SPACE)) {
+                    4 -> Indentation.FOUR_SPACES
+                    2 -> Indentation.TWO_SPACES
+                    1 -> Indentation.ONE_SPACE
+                    else -> throw error(peek(), "Invalid indentation. $amount spaces found. Allowed: 1, 2, 4.")
+                }
+            }
+            else -> Indentation.NONE
+        }
+    }
+
+    /**
+     * Consumes all tokens of the given type in a row. (on the same line)
+     * @return the amount of tokens consumed.
+     */
+    private fun matchAmount(type: TokenType): Int {
+        var amount = 0
+        val line = peek().line
+        while (check(type)) {
+            if (peek().line != line) break // Stop if the line changes
+            advance()
+            amount++
+        }
+
+        return amount
+    }
 
     private fun match(vararg types: TokenType): Boolean {
         for (type in types) {
@@ -318,6 +425,21 @@ class Parser(private val tokens: List<Token>) {
         }
 
         return false
+    }
+
+    /**
+     * Consumes all tokens of the given type in a row. (on the same line)
+     * @return the amount of tokens consumed.
+     */
+    private fun checkAmount(type: TokenType): Int {
+        var count = 0
+        val line = peek().line
+        while (peek(count).type == type) {
+            if (peek(count).line != line) break // Stop if the line changes
+            count++
+        }
+
+        return count
     }
 
     private fun check(type: TokenType): Boolean {
@@ -334,8 +456,13 @@ class Parser(private val tokens: List<Token>) {
         return peek().type == TokenType.EOF
     }
 
-    private fun peek(): Token {
-        return tokens[current]
+    /**
+     * Peeks the token at the given amount of tokens ahead.
+     * @param skip the amount of tokens to skip. 0 would be the next token.
+     * @return the token at the given amount of tokens ahead.
+     */
+    private fun peek(skip: Int = 0): Token {
+        return tokens[current + skip]
     }
 
     private fun previous(): Token {

--- a/src/main/kotlin/host/minestudio/craftlang/language/scanning/Scanner.kt
+++ b/src/main/kotlin/host/minestudio/craftlang/language/scanning/Scanner.kt
@@ -13,7 +13,7 @@ class Scanner(private val source: String) {
         "else" to TokenType.ELSE,
         "false" to TokenType.FALSE,
         "for" to TokenType.FOR,
-        "fun" to TokenType.FUN,
+        "function" to TokenType.FUNCTION,
         "if" to TokenType.IF,
         "null" to TokenType.NULL,
         "or" to TokenType.OR,

--- a/src/main/kotlin/host/minestudio/craftlang/language/scanning/Scanner.kt
+++ b/src/main/kotlin/host/minestudio/craftlang/language/scanning/Scanner.kt
@@ -45,8 +45,6 @@ class Scanner(private val source: String) {
         when (val c = advance()) {
             '(' -> addToken(TokenType.LEFT_PAREN)
             ')' -> addToken(TokenType.RIGHT_PAREN)
-            '{' -> addToken(TokenType.LEFT_BRACE)
-            '}' -> addToken(TokenType.RIGHT_BRACE)
             ',' -> addToken(TokenType.COMMA)
             '.' -> addToken(TokenType.DOT)
             '-' -> addToken(TokenType.MINUS)
@@ -70,8 +68,16 @@ class Scanner(private val source: String) {
                 }
             }
             ':' -> addToken(if (match(':')) TokenType.DOUBLE_COLON else TokenType.COLON)
-            ' ', '\r', '\t' -> {} // Ignore whitespace.
-            '\n' -> line++
+            ' ', '\t', '\r' -> {} // Ignore whitespace (besides indentation, handled in '\n')
+            '\n' -> {
+                line++
+
+                // At this point, we can't tell how many spaces are in each indentation tier,
+                // so we just parse as single spaces, and determine whether it's single, double, or quad in the parser
+                while (peek() == ' ' || peek() == '\t') {
+                    addToken(if (advance() == ' ') TokenType.SPACE else TokenType.TAB)
+                }
+            }
             '"' -> string()
             else -> {
                 if (isDigit(c)) {

--- a/src/main/kotlin/host/minestudio/craftlang/language/scanning/TokenType.kt
+++ b/src/main/kotlin/host/minestudio/craftlang/language/scanning/TokenType.kt
@@ -19,7 +19,7 @@ enum class TokenType {
     IDENTIFIER, STRING, NUMBER,
 
     // Keywords.
-    AND, CLASS, ELSE, FALSE, FUN, FOR, IF, NULL, OR,
+    AND, CLASS, ELSE, FALSE, FUNCTION, FOR, IF, NULL, OR,
     PRINT, RETURN, SUPER, THIS, TO, TRUE, SET, WHILE,
 
     EOF

--- a/src/main/kotlin/host/minestudio/craftlang/language/scanning/TokenType.kt
+++ b/src/main/kotlin/host/minestudio/craftlang/language/scanning/TokenType.kt
@@ -1,9 +1,12 @@
 package host.minestudio.craftlang.language.scanning
 
 enum class TokenType {
+    // Indentation
+    SPACE, TAB,
+
     // Single-character tokens.
-    LEFT_PAREN, RIGHT_PAREN, LEFT_BRACE, RIGHT_BRACE,
-    COMMA, DOT, MINUS, PLUS, SLASH, STAR,
+    LEFT_PAREN, RIGHT_PAREN, COMMA, DOT,
+    MINUS, PLUS, SLASH, STAR,
 
     // One or two character tokens.
     BANG,


### PR DESCRIPTION
Switched from using `{}` braces to indentation-based syntax for control blocks 
like `if`, `while`, and `for`. This affects all constructs requiring block 
delimiters and may require updates to existing code.

BREAKING CHANGE: Blocks are now determined by indentation instead of braces.